### PR TITLE
Expose ServiceConfig and ModelOptions interfaces at top level

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ const admins = await Users.scan({
 
 ### `class Model<T>`
 
-#### `constructor(options: ModelOptions, config?: ClientOptions): Model<T>`
+#### `constructor(options: ModelOptions, config?: ServiceConfig): Model<T>`
 
 Constructor function that creates a new `Model`.
 
@@ -154,7 +154,7 @@ A low-level DynamoDB client. It has all of the main functionality of the AWS Dyn
 
 This class is similar to the main `Model` class, but offers support for `put` and `update` requests, and doesn't have extra features such as validation and events, and it returns the data directly, rather than converting it to `Documents`.
 
-#### `constructor(tableName: string, clientConfig?: ClientOptions): Model<T>`
+#### `constructor(tableName: string, config?: ServiceConfig): Model<T>`
 
 Constructor function that creates a new `Client`.
 
@@ -162,7 +162,7 @@ Constructor function that creates a new `Client`.
 
 Name of the DynamoDB table to interact with
 
-##### `clientConfig`
+##### `config`
 
 Optional config that is passed directly to the underlying [`AWS.DynamoDB.DocumentClient` service constructor from the AWS SDK.](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB.html#constructor-property)
 

--- a/__tests__/dynamodb-client.test.ts
+++ b/__tests__/dynamodb-client.test.ts
@@ -1,5 +1,9 @@
 import { Endpoint, DynamoDB } from 'aws-sdk';
-import { DynamoDBClient, DynamoDBSet } from '../src/dynamodb-client';
+import {
+  DynamoDBClient,
+  DynamoDBSet,
+  ServiceConfig,
+} from '../src/dynamodb-client';
 import { createSet, Literal } from '../src';
 
 enum UserType {
@@ -86,7 +90,7 @@ const SORTED_USERS_SECONDARY_INDEX: User[] = (function () {
 
 let database: DynamoDBClient<User>;
 
-const dynamoConfig = {
+const dynamoConfig: ServiceConfig = {
   endpoint: new Endpoint('http://localhost:8000').href,
   region: 'local',
   accessKeyId: 'xxx',

--- a/__tests__/model.test.ts
+++ b/__tests__/model.test.ts
@@ -1,6 +1,6 @@
 import { mocked } from 'ts-jest/utils';
 import { Model } from '../src/model';
-import { DynamoDBClient } from '../src/dynamodb-client';
+import { DynamoDBClient, ServiceConfig } from '../src/dynamodb-client';
 import { Document } from '../src/document';
 import { Events } from '../src/events';
 
@@ -28,7 +28,7 @@ beforeEach(() => {
 
 let mockDatabase: DynamoDBClient<any>;
 let mockEvents: Events<any>;
-const config = {};
+const config: ServiceConfig = {};
 const tableName = 'users';
 const schema = {
   validate: jest.fn(),

--- a/src/document-client.ts
+++ b/src/document-client.ts
@@ -1,7 +1,7 @@
 import { DynamoDB } from 'aws-sdk';
 import { ServiceConfigurationOptions } from 'aws-sdk/lib/service';
 
-export type DocumentClientOptions = DynamoDB.DocumentClient.DocumentClientOptions &
+export type ServiceConfig = DynamoDB.DocumentClient.DocumentClientOptions &
   ServiceConfigurationOptions &
   DynamoDB.ClientApiVersions;
 
@@ -24,7 +24,7 @@ export type DynamoDBList =
 export class DocumentClient {
   private documentClient: DynamoDB.DocumentClient;
 
-  constructor(params?: DocumentClientOptions) {
+  constructor(params?: ServiceConfig) {
     this.documentClient = new DynamoDB.DocumentClient(params);
   }
 

--- a/src/dynamodb-client.ts
+++ b/src/dynamodb-client.ts
@@ -1,11 +1,11 @@
 import {
   DocumentClient,
-  DocumentClientOptions,
   IndexName,
   DeleteInput,
   PutInput,
   QueryInput,
   ScanInput,
+  ServiceConfig,
   UpdateInput,
   Key as DocumentClientKey,
   DynamoDBList as DDBList,
@@ -20,6 +20,8 @@ import {
 
 export type DynamoDBList = DDBList;
 export type DynamoDBSet = DDBSet;
+
+export { ServiceConfig };
 
 export interface ScanOptions<T> {
   filters?: ConditionExpressions.Conditions<T>;
@@ -50,12 +52,10 @@ export interface DeleteOptions<T> {
 
 export type Key<T> = Partial<T>;
 
-export type ClientOptions = DocumentClientOptions;
-
 export class DynamoDBClient<T> {
   private documentClient: DocumentClient;
 
-  constructor(private tableName: string, config: DocumentClientOptions = {}) {
+  constructor(private tableName: string, config: ServiceConfig = {}) {
     this.documentClient = new DocumentClient({
       ...config,
       params: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { Model } from './model';
-export { DynamoDBClient as Client } from './dynamodb-client';
+export { Model, ModelOptions } from './model';
+export { DynamoDBClient as Client, ServiceConfig } from './dynamodb-client';
 export { createSet } from './document-client';
 export { Literal } from './expression-parsers/updates';

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,15 +1,15 @@
 import {
   DynamoDBClient,
-  ClientOptions,
   DeleteOptions,
   Key,
   QueryOptions,
   ScanOptions,
+  ServiceConfig,
 } from './dynamodb-client';
 import { Document, Schema } from './document';
 import { Events, EventName, EventCallback } from './events';
 
-interface ModelOptions<T> {
+export interface ModelOptions<T> {
   table: string;
   schema: Schema<T>;
 }
@@ -19,7 +19,7 @@ export class Model<T> {
   private events: Events<Document<T>> = new Events();
   private schema: Schema<T>;
 
-  constructor(options: ModelOptions<T>, config?: ClientOptions) {
+  constructor(options: ModelOptions<T>, config?: ServiceConfig) {
     this.db = new DynamoDBClient(options.table, config);
     this.schema = options.schema;
   }


### PR DESCRIPTION
# Description

The `Model` and `DynamoDBClient` constructors have parameters of type `ModelOptions` and `ServiceConfig`. Currently you only get the typing benefits if you define these parameters inline.

This PR exposes these types as part of the main API. Exposing them at the top level API means you can define them as separate variables - especially useful for the `ServiceConfig` if you're creating more than one model with the same config.

```ts
const userModelOps: ModelOptions<UserProps> = {
  table: 'users',
  schema: ...,
};

const orderModelOps: ModelOptions<OrderProps> = {
  table: 'orders',
  schema: ...,
};

const serviceConfig: ServiceConfig = {
  region: 'eu-west-1',
  endpoint: 'https://example.com:8000',
};

const User = new jedlik.Model(userModelOpts, serviceConfig);
const Order = new jedlik.Model(orderModelOpts, serviceConfig);
```

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation