### PR TITLE
Doc fix: @hapi/joi is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,11 @@ NPM:
 
 ## Usage
 
+You can use package like [joi](https://www.npmjs.com/package/joi) to validate the schema.
+
 ```ts
 import * as jedlik from '@peak-ai/jedlik';
-import * as Joi from '@hapi/joi';
+import * as Joi from 'joi';
 
 interface UserProps {
   id: number;
@@ -24,7 +26,7 @@ interface UserProps {
 }
 
 const schema = Joi.object({
-  id: Joi.string().required(),
+  id: Joi.number().required(),
   name: Joi.string().required(),
   type: Joi.string().allow('admin', 'user').required(),
 });


### PR DESCRIPTION
# Description
@hapi/joi is deprecated, the example code seems to work with suggested package `joi`

*Depends on or solve any issue:*
- Links to any issues it is related to

_Description of what this PR does. What have you added or changed, and why?_

- [ ] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation

# Steps to test
1.
2.
3.
